### PR TITLE
Update Mailer.php

### DIFF
--- a/src/Mailer.php
+++ b/src/Mailer.php
@@ -28,7 +28,7 @@ class Mailer extends BaseMailer
         if (!isset($this->apiKey, $this->domain)) {
             throw new InvalidConfigException('Invalid mailer configuration');
         }
-        $this->client = \Yii::createObject(Mailgun::class, [$this->apiKey]);
+        $this->client = Mailgun::create($this->apiKey);
     }
 
     /**


### PR DESCRIPTION
Creating an object by the constructor is deprecated by the latest Mailgun lib, use ``Mailgun::create()`` instead.